### PR TITLE
fix/42 await end betting round

### DIFF
--- a/backend/app/api/game.py
+++ b/backend/app/api/game.py
@@ -326,7 +326,7 @@ async def player_action(
         game = await service.process_action(
             game_id, player.player_id, domain_action, action_request.amount
         )
-        success = poker_game.process_action(player, action, action_request.amount)
+        success = await poker_game.process_action(player, action, action_request.amount)
 
         if not success:
             return ActionResponse(

--- a/backend/app/api/game_ws.py
+++ b/backend/app/api/game_ws.py
@@ -633,7 +633,7 @@ async def process_action_message(
         
         # Process directly in poker game for current state
         logging.info(f"[WS-ACTION-{execution_id}] About to call process_action with player {player.name}, action {action_type}, amount {action_amount}")
-        success = poker_game.process_action(player, action_type, action_amount)
+        success = await poker_game.process_action(player, action_type, action_amount)
         
         logging.info(f"[WS-ACTION-{execution_id}] After process_action - to_act: {poker_game.to_act}")
         logging.info(f"[WS-ACTION-{execution_id}] PokerGame process_action result: {success}")

--- a/backend/app/services/game_service.py
+++ b/backend/app/services/game_service.py
@@ -1020,7 +1020,7 @@ class GameService:
                     poker_action = getattr(PokerPlayerAction, action_map[action])
                     
                     # Process the action
-                    poker_game.process_action(poker_player, poker_action, amount)
+                    await poker_game.process_action(poker_player, poker_action, amount)
                     
                     # ------------------------------------------------------------------
                     # HAND COMPLETE – HANDLE SHOWDOWN SEQUENCE FOR **HUMAN** ACTION PATH
@@ -1498,7 +1498,7 @@ class GameService:
             async with game_lock:
                 logging.info(f"[AI-ACTION-{execution_id}] Lock acquired - Processing {poker_action.name} {action_amount if action_amount is not None else ''} in PokerGame")
                 logging.info(f"[AI-ACTION-{execution_id}] Before process_action - to_act: {poker_game.to_act}")
-                success = poker_game.process_action(poker_player, poker_action, action_amount)
+                success = await poker_game.process_action(poker_player, poker_action, action_amount)
                 logging.info(f"[AI-ACTION-{execution_id}] After process_action - to_act: {poker_game.to_act}")
                 logging.info(f"[AI-ACTION-{execution_id}] PokerGame process_action result: {success}")
                 # If invalid, force a fold to advance game state
@@ -1507,7 +1507,7 @@ class GameService:
                     logging.error(f"[AI-ACTION-{execution_id}] Invalid AI action {poker_action.name} {action_amount}. Forcing FOLD to prevent stall.")
                     # Force fold
                     fold_action = PokerPlayerAction.FOLD
-                    poker_game.process_action(poker_player, fold_action, None)
+                    await poker_game.process_action(poker_player, fold_action, None)
                     # Notify forced fold
                     from app.core.websocket import game_notifier
                     await game_notifier.notify_player_action(
@@ -1828,13 +1828,13 @@ class GameService:
                 if poker_player and poker_game:
                     logging.warning(f"AI Action Error: Using fallback {fallback_action_name} for player {player_id}")
                     # Process the fallback action
-                    action_success = poker_game.process_action(poker_player, poker_action, None)
+                    action_success = await poker_game.process_action(poker_player, poker_action, None)
                     if not action_success and fallback_action_name != "FOLD":
                         # If the chosen action fails, fall back to FOLD
                         logging.warning(f"AI Action Error: {fallback_action_name} failed, forcing FOLD")
                         poker_action = PokerPlayerAction.FOLD
                         fallback_action_name = "FOLD"
-                        poker_game.process_action(poker_player, poker_action, None)
+                        await poker_game.process_action(poker_player, poker_action, None)
                     # Compute totals for log
                     fs_post_street = poker_player.current_bet
                     fs_post_hand = poker_player.total_bet

--- a/backend/tests/api/test_ai_integration.py
+++ b/backend/tests/api/test_ai_integration.py
@@ -126,7 +126,7 @@ async def test_ai_turn_triggering(reset_game_service, mock_memory_integration):
         # If current player is human, make a move to get to AI's turn
         if from_domain_current_player.is_human:
             # Mock process_action to make a human action
-            poker_game.process_action(current_player, PokerPlayerAction.CALL, None)
+            asyncio.run(poker_game.process_action(current_player, PokerPlayerAction.CALL, None))
             
             # Update current_player to the next player
             active_players = [p for p in poker_game.players 
@@ -329,7 +329,7 @@ async def test_error_handling_in_ai_action(reset_game_service, mock_memory_integ
         # If current player is human, make a move to get to AI's turn
         if from_domain_current_player.is_human:
             # Mock process_action to make a human action
-            poker_game.process_action(current_player, PokerPlayerAction.CALL, None)
+            asyncio.run(poker_game.process_action(current_player, PokerPlayerAction.CALL, None))
             
             # Update current_player to the next player
             active_players = [p for p in poker_game.players 

--- a/backend/tests/test_side_pots.py
+++ b/backend/tests/test_side_pots.py
@@ -2,8 +2,14 @@
 Tests specifically for side pot scenarios in the poker game.
 """
 import pytest
+import asyncio
 from app.core.cards import Card, Rank, Suit
 from app.core.poker_game import PokerGame, Player, PlayerAction, PlayerStatus, BettingRound, Pot
+
+
+def run_action(game: PokerGame, player: Player, action: PlayerAction, amount=None):
+    """Helper to run async process_action synchronously."""
+    return asyncio.run(game.process_action(player, action, amount))
 
 
 def test_basic_side_pot_creation():
@@ -84,29 +90,29 @@ def test_multiple_all_ins_multiple_side_pots():
     game.start_hand()
     
     # Player 4 (UTG+1) raises to 80
-    game.process_action(p4, PlayerAction.RAISE, 80)
+    run_action(game, p4, PlayerAction.RAISE, 80)
     
     # Player 0 (Button) calls
-    game.process_action(p0, PlayerAction.CALL)
+    run_action(game, p0, PlayerAction.CALL)
     
     # Player 1 (SB) goes all-in with 100 total (90 more)
-    game.process_action(p1, PlayerAction.ALL_IN)
+    run_action(game, p1, PlayerAction.ALL_IN)
     assert p1.status == PlayerStatus.ALL_IN
     assert p1.chips == 0
     
     # Player 2 (BB) goes all-in with 250 total
-    game.process_action(p2, PlayerAction.ALL_IN)
+    run_action(game, p2, PlayerAction.ALL_IN)
     assert p2.status == PlayerStatus.ALL_IN
     assert p2.chips == 0
     
     # Player 3 (UTG) goes all-in with 400 total
-    game.process_action(p3, PlayerAction.ALL_IN)
+    run_action(game, p3, PlayerAction.ALL_IN)
     assert p3.status == PlayerStatus.ALL_IN
     assert p3.chips == 0
     
     # Player 4 and Player 0 call all the all-ins
-    game.process_action(p4, PlayerAction.CALL)
-    game.process_action(p0, PlayerAction.CALL)
+    run_action(game, p4, PlayerAction.CALL)
+    run_action(game, p0, PlayerAction.CALL)
     
     # Force side pot creation
     game._create_side_pots()

--- a/docs/AI_INTEGRATION.md
+++ b/docs/AI_INTEGRATION.md
@@ -1247,7 +1247,7 @@ async def _request_and_process_ai_action(self, game_id: str, player_id: str):
         action, amount, metadata = AgentResponseParser.parse_response(ai_decision)
         
         # Process the action in the poker game
-        poker_game.process_action(poker_player, poker_action, action_amount)
+        await poker_game.process_action(poker_player, poker_action, action_amount)
         
         # Notify clients
         await game_notifier.notify_player_action(game_id, player_id, action_type, action_amount)
@@ -1273,7 +1273,7 @@ async def _request_and_process_ai_action(self, game_id: str, player_id: str):
         
     except Exception as e:
         # Default to fold on error
-        poker_game.process_action(poker_player, PokerPlayerAction.FOLD, None)
+        await poker_game.process_action(poker_player, PokerPlayerAction.FOLD, None)
 ```
 
 #### WebSocket Game Flow Updates
@@ -1284,7 +1284,7 @@ The WebSocket handler has been updated to check for AI players and trigger their
 async def process_action_message(websocket, game_id, message, player_id, service):
     """Process a player action WebSocket message."""
     # Process the human player's action
-    success = poker_game.process_action(player, action_type, action_amount)
+    success = await poker_game.process_action(player, action_type, action_amount)
     
     # Notify about updated game state
     await game_notifier.notify_game_update(game_id, poker_game)


### PR DESCRIPTION
## Summary
- make `_end_betting_round` async and await notifier
- update `process_action` to async and await end-of-round logic
- adjust service and API layers for async `process_action`
- update documentation and tests for new async methods

## Testing
- `cd backend && pytest`