### PR TITLE
Add setup script and frontend lint config

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -1,0 +1,20 @@
+{
+  "env": {
+    "browser": true,
+    "es2021": true
+  },
+  "extends": [
+    "react-app",
+    "plugin:@typescript-eslint/recommended",
+    "prettier"
+  ],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "plugins": [
+    "@typescript-eslint"
+  ],
+  "rules": {}
+}

--- a/frontend/.prettierrc
+++ b/frontend/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "es5"
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,11 +22,20 @@
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"
   },
+  "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^6.8.0",
+    "@typescript-eslint/parser": "^6.8.0",
+    "eslint": "^8.57.0",
+    "eslint-config-prettier": "^9.1.0",
+    "prettier": "^3.2.5"
+  },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "lint": "eslint src --ext .ts,.tsx",
+    "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,css,md}\""
   },
   "eslintConfig": {
     "extends": [

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+cd "$(dirname "$0")"
+
+# Backend dependencies
+python -m pip install --upgrade pip
+pip install -r backend/requirements.txt
+pip install -e backend/[dev]
+
+# AI module dependencies
+pip install -r ai/requirements.txt
+
+# Frontend dependencies
+cd frontend
+npm install
+cd ..
+
+echo "Setup complete!"


### PR DESCRIPTION
## Summary
- add frontend linting and formatting scripts
- add ESLint and Prettier configs
- provide repo setup script for installing dependencies

## Testing
- `black . && mypy .` *(fails: Function is missing a return type annotation)*
- `pytest`
- `python -m ai.tests.run_tests` *(fails: ModuleNotFoundError)*
- `npm run lint` *(fails: missing eslint-config-prettier when dependencies not installed)*
- `npm run format`
- `npm test --silent -- -u` *(fails: tests failing)*