### PR TITLE
[Issue #11] Notify clients when rounds advance

### DIFF
--- a/backend/app/core/poker_game.py
+++ b/backend/app/core/poker_game.py
@@ -1915,12 +1915,39 @@ class PokerGame:
         # Move to the next round
         if self.current_round == BettingRound.PREFLOP:
             self.deal_flop()
+            if self.game_id:
+                try:
+                    from app.core.websocket import game_notifier
+                    await game_notifier.notify_new_round(
+                        self.game_id, self.current_round.name, self.community_cards
+                    )
+                    await asyncio.sleep(0.1)
+                except Exception as e:
+                    logging.error(f"Error sending new round notification: {e}")
             return False
         elif self.current_round == BettingRound.FLOP:
             self.deal_turn()
+            if self.game_id:
+                try:
+                    from app.core.websocket import game_notifier
+                    await game_notifier.notify_new_round(
+                        self.game_id, self.current_round.name, self.community_cards
+                    )
+                    await asyncio.sleep(0.1)
+                except Exception as e:
+                    logging.error(f"Error sending new round notification: {e}")
             return False
         elif self.current_round == BettingRound.TURN:
             self.deal_river()
+            if self.game_id:
+                try:
+                    from app.core.websocket import game_notifier
+                    await game_notifier.notify_new_round(
+                        self.game_id, self.current_round.name, self.community_cards
+                    )
+                    await asyncio.sleep(0.1)
+                except Exception as e:
+                    logging.error(f"Error sending new round notification: {e}")
             return False
         elif self.current_round == BettingRound.RIVER:
             return self._handle_showdown()


### PR DESCRIPTION
## Summary
- send `notify_new_round` websocket event after flop, turn, and river are dealt
- cover new notification with test

## Testing
- `cd backend && mypy app/core/poker_game.py tests/test_poker_game.py`
- `cd backend && pytest -q`