### PR TITLE
fix: delay next action until street reveal ends

### DIFF
--- a/backend/app/api/game_ws.py
+++ b/backend/app/api/game_ws.py
@@ -354,6 +354,8 @@ async def websocket_endpoint(
                 elif message.get("type") == "animation_done":
                     # Client signals a visual animation step is complete
                     step = message.get("data", {}).get("stepType")
+                    if step:
+                        game_notifier.signal_animation_done(game_id, step)
                     if step == "hand_visually_concluded":
                         # Advance dealer button and start next hand
                         poker_game = service.poker_games.get(game_id)

--- a/backend/app/core/poker_game.py
+++ b/backend/app/core/poker_game.py
@@ -1919,9 +1919,18 @@ class PokerGame:
                 try:
                     from app.core.websocket import game_notifier
                     await game_notifier.notify_new_round(
-                        self.game_id, self.current_round.name, self.community_cards
+                        self.game_id,
+                        self.current_round.name,
+                        self.community_cards,
+                        auto_request=False,
                     )
-                    await asyncio.sleep(0.1)
+                    try:
+                        await game_notifier.wait_for_animation(
+                            self.game_id, "street_dealt", timeout=2.0
+                        )
+                    except Exception:
+                        await asyncio.sleep(1.0)
+                    await game_notifier.notify_action_request(self.game_id, self)
                 except Exception as e:
                     logging.error(f"Error sending new round notification: {e}")
             return False
@@ -1931,9 +1940,18 @@ class PokerGame:
                 try:
                     from app.core.websocket import game_notifier
                     await game_notifier.notify_new_round(
-                        self.game_id, self.current_round.name, self.community_cards
+                        self.game_id,
+                        self.current_round.name,
+                        self.community_cards,
+                        auto_request=False,
                     )
-                    await asyncio.sleep(0.1)
+                    try:
+                        await game_notifier.wait_for_animation(
+                            self.game_id, "street_dealt", timeout=2.0
+                        )
+                    except Exception:
+                        await asyncio.sleep(1.0)
+                    await game_notifier.notify_action_request(self.game_id, self)
                 except Exception as e:
                     logging.error(f"Error sending new round notification: {e}")
             return False
@@ -1943,9 +1961,18 @@ class PokerGame:
                 try:
                     from app.core.websocket import game_notifier
                     await game_notifier.notify_new_round(
-                        self.game_id, self.current_round.name, self.community_cards
+                        self.game_id,
+                        self.current_round.name,
+                        self.community_cards,
+                        auto_request=False,
                     )
-                    await asyncio.sleep(0.1)
+                    try:
+                        await game_notifier.wait_for_animation(
+                            self.game_id, "street_dealt", timeout=2.0
+                        )
+                    except Exception:
+                        await asyncio.sleep(1.0)
+                    await game_notifier.notify_action_request(self.game_id, self)
                 except Exception as e:
                     logging.error(f"Error sending new round notification: {e}")
             return False

--- a/backend/tests/test_poker_game.py
+++ b/backend/tests/test_poker_game.py
@@ -1050,6 +1050,12 @@ async def test_round_bets_finalized_notification(monkeypatch):
     monkeypatch.setattr(
         "app.core.websocket.game_notifier.notify_round_bets_finalized", mock_notify
     )
+    monkeypatch.setattr(
+        "app.core.websocket.game_notifier.wait_for_animation", AsyncMock()
+    )
+    monkeypatch.setattr(
+        "app.core.websocket.game_notifier.notify_action_request", AsyncMock()
+    )
 
     await game._end_betting_round()
 
@@ -1080,6 +1086,12 @@ async def test_new_round_notification(monkeypatch):
         "app.core.websocket.game_notifier.notify_new_round",
         mock_notify,
     )
+    monkeypatch.setattr(
+        "app.core.websocket.game_notifier.wait_for_animation", AsyncMock()
+    )
+    monkeypatch.setattr(
+        "app.core.websocket.game_notifier.notify_action_request", AsyncMock()
+    )
 
     await game._end_betting_round()
 
@@ -1090,3 +1102,4 @@ async def test_new_round_notification(monkeypatch):
     assert args[0] == "test_game"
     assert args[1] == "FLOP"
     assert isinstance(args[2], list)
+    assert args[3] is False


### PR DESCRIPTION
## Summary
- wait for street reveal animation before sending action requests
- signal animation completion from websocket events
- test new wait logic in PokerGame

## Testing
- `mypy app/api/game_ws.py app/core/websocket.py app/core/poker_game.py tests/test_poker_game.py`
- `pytest tests/test_poker_game.py`
- `pytest`