### PR TITLE
fix: zero pots before announcing winners #0

### DIFF
--- a/backend/app/services/game_service.py
+++ b/backend/app/services/game_service.py
@@ -1132,6 +1132,11 @@ class GameService:
                                     'amount': amount,
                                     'winners': winners_list
                                 })
+
+                            # Zero pots so display resets before animations
+                            for pot in poker_game.pots:
+                                pot.amount = 0
+
                             await game_notifier.notify_pot_winners_determined(game_id, pots_info)
                         except Exception as e:
                             logging.error(f"Error announcing pot winners: {e}")
@@ -1657,6 +1662,11 @@ class GameService:
                                 'amount': amount,
                                 'winners': winners_list
                             })
+
+                        # Set pots to zero so table clears before animations
+                        for pot in poker_game.pots:
+                            pot.amount = 0
+
                         await game_notifier.notify_pot_winners_determined(game_id, pots_info)
                     except Exception as e:
                         logging.error(f"Error announcing pot winners (AI path): {e}")


### PR DESCRIPTION
## Summary
- clear pot amounts prior to `pot_winners_determined` notification so the frontend can hide the pot before animations

## Testing
- `pytest`
- `mypy app` *(fails: cannot find module `ai.memory_integration` and other missing type hints)*