### PR TITLE
fix: zero pots before announcing winners #0

### DIFF
--- a/ai/memory_integration.py
+++ b/ai/memory_integration.py
@@ -19,10 +19,10 @@ from ai.llm_service import LLMService
 
 # Import agent definitions if available
 try:
-    from agents.base_agent import PokerAgent
-    from agents.tag_agent import TAGAgent
-    from agents.lag_agent import LAGAgent
-    from agents.adaptable_agent import AdaptableAgent
+    from ai.agents.base_agent import PokerAgent
+    from ai.agents.tag_agent import TAGAgent
+    from ai.agents.lag_agent import LAGAgent
+    from ai.agents.adaptable_agent import AdaptableAgent
     AGENTS_AVAILABLE = True
 except ImportError:
     AGENTS_AVAILABLE = False

--- a/backend/app/services/game_service.py
+++ b/backend/app/services/game_service.py
@@ -1132,6 +1132,11 @@ class GameService:
                                     'amount': amount,
                                     'winners': winners_list
                                 })
+
+                            # Zero pots so display resets before animations
+                            for pot in poker_game.pots:
+                                pot.amount = 0
+
                             await game_notifier.notify_pot_winners_determined(game_id, pots_info)
                         except Exception as e:
                             logging.error(f"Error announcing pot winners: {e}")
@@ -1657,6 +1662,11 @@ class GameService:
                                 'amount': amount,
                                 'winners': winners_list
                             })
+
+                        # Set pots to zero so table clears before animations
+                        for pot in poker_game.pots:
+                            pot.amount = 0
+
                         await game_notifier.notify_pot_winners_determined(game_id, pots_info)
                     except Exception as e:
                         logging.error(f"Error announcing pot winners (AI path): {e}")

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -39,6 +39,7 @@ warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true
 disallow_incomplete_defs = true
+mypy_path = ".."
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
## Summary
- clear pot amounts prior to `pot_winners_determined` notification so the frontend can hide the pot before animations
- update mypy configuration so the `ai` package is located
- fix agent imports inside `memory_integration`

## Testing
- `pytest`
- `python -m ai.tests.run_tests`
- `mypy app/main.py` *(fails: missing type hints in ai modules)*