### PR TITLE
[Issue #88] fix frontend highlight clearing

### DIFF
--- a/frontend/requirements.txt
+++ b/frontend/requirements.txt
@@ -1,0 +1,1 @@
+react-router-dom

--- a/frontend/src/hooks/useGameWebSocket.ts
+++ b/frontend/src/hooks/useGameWebSocket.ts
@@ -920,7 +920,9 @@ useEffect(() => {
                 console.log(`[TURN-TIMEOUT] Action player: ${actionPlayerId}, isLastPlayerAllIn: ${isLastPlayerAllIn}, isInShowdown: ${isNowInShowdown}`);
                 
                 if (isNowInShowdown) {
-                  console.log('[TURN-TIMEOUT] Already in SHOWDOWN, skipping highlight removal (handled by showdown transition)');
+                  console.log('[TURN-TIMEOUT] Already in SHOWDOWN, removing highlight before skipping further handling');
+                  setShowTurnHighlight(false);
+                  setCurrentTurnPlayerId(null);
                   return;
                 }
                 


### PR DESCRIPTION
## Summary
- ensure highlight is cleared if showdown has already started
- add `react-router-dom` listing for build requirements

## Testing
- `npm run lint`
- `CI=true npm test --silent` *(fails: Cannot find module 'react-router-dom')*
- `npm run build`
